### PR TITLE
Finally bookkeeping=False or bookkeeping=True is handled correctly!

### DIFF
--- a/glacier/GlacierWrapper.py
+++ b/glacier/GlacierWrapper.py
@@ -216,6 +216,14 @@ ap-northeast-1 (Asia-Pacific - Tokyo)"""
 
             # TODO: give SimpleDB its own class? Or move the few calls
             # we need to glaciercorecalls?
+
+            if not self.bookkeeping_domain_name:
+                raise InputException(
+                    '''\
+Bookkeeping enabled but no Amazon SimpleDB domain given.
+Provide a domain in either the config file or via the
+command line, or disable bookkeeping.''',
+                    code="SdbConnectionError")
             
             if not hasattr(self, 'sdb_conn'):
                 try:

--- a/glacier/glacier.py
+++ b/glacier/glacier.py
@@ -489,10 +489,10 @@ def main():
                        default=default("region"),
                        help="Region where you want to store \
                              your archives " + help_msg_config)
-    bookkeeping = default("bookkeeping") and True
+    bookkeeping = True if default('bookkeeping') == 'True' else False
     group.add_argument('--bookkeeping',
                        required=False,
-                       default=bookkeeping,
+                       default=default("bookkeeping"),
                        action="store_true",
                        help="Should we keep book of all created archives.\
                              This requires a Amazon SimpleDB account and its \
@@ -746,7 +746,7 @@ at hand.''')
     args = parser.parse_args(remaining_argv)
     
     args.logtostdout = logtostdout
-
+    
     # Run the subcommand.
     args.func(args)
 


### PR DESCRIPTION
The problem: `default("bookkeeping")` gives the result 'True' or 'False' as string value, not the boolean True or boolean False. So we must use string comparison, not boolean comparison. Tricky!

Also added check in sdb_connect that we actually have a domain if bookkeeping is switched on; if not it throws an exception telling the user to set a domain or to switch off bookkeeping alltogether.
