### PR TITLE
Fixing resuming with uploadid

### DIFF
--- a/glacier/GlacierWrapper.py
+++ b/glacier/GlacierWrapper.py
@@ -996,7 +996,7 @@ using %s MB parts to upload."% part_size)
                 # function to handle non-sequential parts.
                 for part in list_parts_response['Parts']:
                     start, stop = (int(p) for p in part['RangeInBytes'].split('-'))
-                    print 'start: %s, current position: %s'% (start, current_position)
+                    stop += 1
                     if not start == current_position:
                         if stdin:
                             raise InputException(


### PR DESCRIPTION
Amazon returns inclusive byte ranges, so in order to resume to work correctly we need to increase the "stop" variable, otherwise hashes don't match and worker.uploaded_size has incorrect value.
