### PR TITLE
We have to call .read() on layer1.upload_part's response,…

### DIFF
--- a/glacier/glaciercorecalls.py
+++ b/glacier/glaciercorecalls.py
@@ -121,12 +121,13 @@ class GlacierWriter(object):
                     "x-amz-content-sha256": hashlib.sha256(data).hexdigest()
                   }
 
-        self.connection.upload_part(self.vault_name,
+        response = self.connection.upload_part(self.vault_name,
                                     self.uploadid,
                                     hashlib.sha256(data).hexdigest(),
                                     bytes_to_hex(part_tree_hash),
                                     (self.uploaded_size, self.uploaded_size+len(data)-1),
                                     data)
+        response.read()
 
 ##        retries = 0
 ##        while True:


### PR DESCRIPTION
…otherwise HostConnectionPool will not reuse that connection, and eventually (given a large enough file) we will run out of available connections and crash with a weird error.
