### PR TITLE
"Term" output mode for small terminal windows

### DIFF
--- a/glacier/glacier.py
+++ b/glacier/glacier.py
@@ -46,6 +46,10 @@ def output_headers(headers, output):
         
     if output == 'json':
         print json.dumps(headers)
+		
+    if output == 'term':
+        for row in rows:
+            print "%-16s%s" % (row[0], row[1])
 
 def output_table(results, output, keys=None, sort_key=None):
     """
@@ -87,6 +91,18 @@ def output_table(results, output, keys=None, sort_key=None):
     if output == 'json':
         print json.dumps(results)
 
+    if output == 'term':
+        if len(results) == 0:
+            print 'No output!'
+            return
+
+        headers = [keys[k] for k in keys.keys()] if keys else results[0].keys()
+        table = PrettyTable(headers)
+        for line in results:
+			for k in (keys.keys() if keys else headers):
+				print "%-16s%s" % (k, line[k] if k in line else '')
+			print "";
+		
 def output_msg(msg, output, success=True):
     """
     In case of a single message output, e.g. nothing found.
@@ -105,6 +121,9 @@ def output_msg(msg, output, success=True):
             
     if output == 'json':
         print json.dumps(msg)
+
+    if output == 'term':
+        print msg
         
     if not success:
         sys.exit(125)
@@ -625,8 +644,8 @@ def main():
     group.add_argument('--output',
                        required=False,
                        default=default('output') if default('output') else 'print',
-                       choices=['print', 'csv', 'json'],
-                       help='Set how to return results: print to the screen, or as csv resp. json string.')
+                       choices=['print', 'term', 'csv', 'json'],
+                       help='Set how to return results: print to the screen as a table, terminal friendly key-value or as csv resp. json string.')
 
     # SimpleDB settings
     group = parser.add_argument_group('sdb')

--- a/glacier/glacier.py
+++ b/glacier/glacier.py
@@ -49,7 +49,7 @@ def output_headers(headers, output):
 		
     if output == 'term':
         for row in rows:
-            print "%-16s%s" % (row[0], row[1])
+            print "%-15s %s" % (row[0], row[1])
 
 def output_table(results, output, keys=None, sort_key=None):
     """
@@ -100,7 +100,7 @@ def output_table(results, output, keys=None, sort_key=None):
         table = PrettyTable(headers)
         for line in results:
 			for k in (keys.keys() if keys else headers):
-				print "%-16s%s" % (k, line[k] if k in line else '')
+				print "%-15s %s" % (k, line[k] if k in line else '')
 			print "";
 		
 def output_msg(msg, output, success=True):


### PR DESCRIPTION
I have found the "print" output to be a bit hard to follow on a small (eg. 80 chars wide) terminal window when the long archive_ids break pretty print table structure. To make the program more usable for terminals, I propose a new "term" output mode  as implemented in this pull request.

The new mode prints headers for each value and separates each row with an empty line. This makes it easier for a human user to spot description (file name) from the terminal output and to differentiate archive_id from hash, even if lines are wrapped. Here's an example output:

<pre>
archive_id      rpf7-cSGtEtpOOJjDEgFPiMjF-TYapWk0SK_IgU7nlWtitDczJ--9F55ZeHI4OYxpkWNHqViaPIZYZCh9twYYgpkmxfIznTPO3Bu12xRgKaz4Bj8-VqWN7pf7I2UzzP3vJem_k8Hfg
hash            a3003bad34d4d9c42971aefb8c5121f9b40c04e2b5b6090e39199b40d0e6b3ae
description     20130429-photos-2006.tgz.gpg
region          eu-west-1
date            2013-04-29 16:29:31+00:00
vault           jarno-personal-backup
size            1010737218

archive_id      s3_Jh3tzVVJUFy5_ooEXS16vku1dJw-lfn3msFJJlASrRgBptwkyABXul4w1DAuqowHhpmAjnTZl7Sh5IIaPuo9gJ9hQXO16UwqIjOJdAX199CTSPJkfRNoP07kSJvk2t_LAJylHqw
hash            aec66deb80ab86bd226aa691c7b2d6ab5e397beb79677ec01c033288b75be4a
description     20130405-photos-2003.tgz.gpg
region          eu-west-1
date            2013-04-05 00:17:17+00:00
vault           jarno-personal-backup
size            382171544

....
</pre>
