### PR TITLE
Fix "not all arguments converted"; loglevel=DEBUG

### DIFF
--- a/glacier/GlacierWrapper.py
+++ b/glacier/GlacierWrapper.py
@@ -1988,7 +1988,8 @@ your archive ID is correct, and start a retrieval job using \
 Creating GlacierWrapper instance with
     aws_access_key=%s,
     aws_secret_key=%s,
-    bookkeeping=%r,
+    bookkeeping=%s,
+    nobookkeeping=%s,
     bookkeeping_domain_name=%s,
     region=%s,
     sdb_access_key=%s,


### PR DESCRIPTION
Was getting:

TypeError: not all arguments converted during string formatting

"no_bookkeeping" wasn't being converted.
