### PR TITLE
Fixed bookkeeping bug in rmarchive

### DIFF
--- a/glacier/GlacierWrapper.py
+++ b/glacier/GlacierWrapper.py
@@ -1553,7 +1553,7 @@ your archive ID is correct, and start a retrieval job using \
         # Remove the listing from the bookkeeping database.
         if self.bookkeeping:
             try:
-                item = self.sdb_domain.get_item(archive_id)
+                item = self.sdb_domain.select("select * from `%s` where archive_id='%s'" % (self.sdb_domain.name, archive_id)).next()
                 if item:
                     self.sdb_domain.delete_item(item)
             except boto.exception.SDBResponseError as e:


### PR DESCRIPTION
In master, rmarchive doesn't actually remove archives from the bookkeeping database. The problem is that rmarchive tries to fetch the database entry for the archive using sdb_domain.get_item(archive_id), but get_item actually searches by the item name (which is the same as the filename). I fixed this by using sdb_domain.select to query by archive_id instead.

In my limited testing this seems to work correctly.
