### PR TITLE
Choose the most recent inventory

### DIFF
--- a/glacier/GlacierWrapper.py
+++ b/glacier/GlacierWrapper.py
@@ -1615,7 +1615,7 @@ your archive ID is correct, and start a retrieval job using \
             # in progress job.
             job_list = self.list_jobs(vault_name)
             inventory_done = False
-            for job in job_list:
+            for job in sorted(job_list, key=lambda x: x['CompletionDate'], reverse=True):
                 if job['Action'] == "InventoryRetrieval":
 
                     # As soon as a finished inventory job is found, we're done.


### PR DESCRIPTION
I found that "glacier-cmd inventory <vault-name>" always returns the same inventory - the first one I ever created, back when the vault was empty. it seems to me that it needs to return the most recent inventory. 
