### PR TITLE
Do not emit None message

### DIFF
--- a/glacier/glacier.py
+++ b/glacier/glacier.py
@@ -96,15 +96,16 @@ def output_msg(msg, output, success=True):
     :param success: whether the operation was a success or not.
     :type success: boolean
     """
-    if output == 'print':
-        print msg
-        
-    if output == 'csv':
-        csvwriter = csv.writer(sys.stdout, quoting=csv.QUOTE_ALL)
-        csvwriter.writerow(msg)
-            
-    if output == 'json':
-        print json.dumps(msg)
+    if msg is not None:
+        if output == 'print':
+            print msg
+
+        if output == 'csv':
+            csvwriter = csv.writer(sys.stdout, quoting=csv.QUOTE_ALL)
+            csvwriter.writerow(msg)
+
+        if output == 'json':
+            print json.dumps(msg)
         
     if not success:
         sys.exit(125)


### PR DESCRIPTION
Previously "glacier-cmd download" emitted a trailing None message:

```
$ glacier-cmd download VAULTNAME zwvjqvd25vxcYLuaGOUhTMi8GW_PQ9M7-a9-Xpr6OX38WhABMBrG4U3w21vO08sgYFNrjRBgNuYiomc7mEkiaojIbkoETF6X1qnSDl-AR-ORzlgjIVud6zWM2R8yjuhg9g5q_M0LVg --outfile out
Wrote 4.0 bytes. Rate 4.00 bytes/s. Rate 1.22 MB/s, average 4.00 bytes/s, ETA 15:08:53.
None
```
