### PR TITLE
Fixed typo in documentation (Usage.rts file)

### DIFF
--- a/doc/Usage.rst
+++ b/doc/Usage.rst
@@ -122,7 +122,7 @@ Give an overview of the available vaults. ::
 Describing status of a vault.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``$ glacier-cmd decribevault <vault name>``
+``$ glacier-cmd describevault <vault name>``
 
 .. program-output:: glacier-cmd describevault -h
 


### PR DESCRIPTION
Small mistake in command in documentation.
